### PR TITLE
fixed test namespaces and class names to comply with PSR-4

### DIFF
--- a/Test/InflectorTest.php
+++ b/Test/InflectorTest.php
@@ -4,7 +4,7 @@
  * @license    LGPL-2.0-or-later
  */
 
-namespace Windwalker\String\Tests;
+namespace Windwalker\String\Test;
 
 use Windwalker\String\StringInflector;
 use Windwalker\Test\TestHelper;

--- a/Test/StringNormaliseTest.php
+++ b/Test/StringNormaliseTest.php
@@ -6,7 +6,7 @@
 
 // phpcs:disable
 
-namespace Windwalker\String\Tests;
+namespace Windwalker\String\Test;
 
 use Windwalker\String\StringNormalise;
 


### PR DESCRIPTION
@asika32764 I've fixed two wrong namespaces in your tests and renamed NormaliseTest.php to StringNormaliseTest.php to comply with the psr-4 standards and avoid composer complaining about autoloading.

Would you mind tagging a new release anytime soon? Thanks.